### PR TITLE
perf(mediator): cache per-request dispatch wrappers

### DIFF
--- a/src/StarterApp.Api/Infrastructure/Mediator/Mediator.cs
+++ b/src/StarterApp.Api/Infrastructure/Mediator/Mediator.cs
@@ -1,7 +1,19 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
+
 namespace StarterApp.Api.Infrastructure.Mediator;
 
 public class Mediator : IMediator
 {
+    // One wrapper is built per concrete request type on first dispatch and cached
+    // for the process lifetime. MakeGenericType / Activator.CreateInstance runs
+    // once per request type — every subsequent SendAsync is a dictionary lookup
+    // plus a strongly-typed virtual call. No MethodInfo.Invoke, no per-call
+    // object[] argument allocation, no per-behavior GetMethod lookup.
+    private static readonly ConcurrentDictionary<Type, object> RequestHandlerWrappers = new();
+    private static readonly ConcurrentDictionary<Type, VoidRequestHandlerWrapper> VoidRequestHandlerWrappers = new();
+    private static readonly ConcurrentDictionary<Type, ValidatorInvoker> ValidatorInvokers = new();
+
     private readonly IServiceProvider _serviceProvider;
 
     public Mediator(IServiceProvider serviceProvider)
@@ -9,89 +21,110 @@ public class Mediator : IMediator
         _serviceProvider = serviceProvider;
     }
 
-    public async Task<TResponse> SendAsync<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
+    public Task<TResponse> SendAsync<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(request);
+
         RunValidators(request);
 
-        var requestType = request.GetType();
-        var responseType = typeof(TResponse);
-        var handlerType = typeof(IRequestHandler<,>).MakeGenericType(requestType, responseType);
+        var wrapper = (RequestHandlerWrapper<TResponse>)RequestHandlerWrappers.GetOrAdd(
+            request.GetType(),
+            static (requestType, responseType) =>
+                Activator.CreateInstance(typeof(RequestHandlerWrapperImpl<,>).MakeGenericType(requestType, responseType))!,
+            typeof(TResponse));
 
-        var handler = _serviceProvider.GetService(handlerType);
-        if (handler == null)
-        {
-            throw new InvalidOperationException($"No handler registered for {requestType.Name}");
-        }
-
-        var method = handlerType.GetMethod(nameof(IRequestHandler<IRequest<TResponse>, TResponse>.HandleAsync));
-        if (method == null)
-        {
-            throw new InvalidOperationException($"HandleAsync method not found on {handlerType.Name}");
-        }
-
-        // Build the innermost delegate (the actual handler)
-        RequestHandlerDelegate<TResponse> handlerDelegate = () =>
-            (Task<TResponse>)method.Invoke(handler, new object[] { request, cancellationToken })!;
-
-        // Wrap with pipeline behaviors (e.g., caching)
-        var behaviorType = typeof(IPipelineBehavior<,>).MakeGenericType(requestType, responseType);
-        var behaviors = _serviceProvider.GetServices(behaviorType).ToList();
-
-        foreach (var behavior in behaviors.AsEnumerable().Reverse())
-        {
-            var currentNext = handlerDelegate;
-            var behaviorMethod = behaviorType.GetMethod(nameof(IPipelineBehavior<IRequest<TResponse>, TResponse>.HandleAsync));
-            handlerDelegate = () =>
-                (Task<TResponse>)behaviorMethod!.Invoke(behavior, new object[] { request, currentNext, cancellationToken })!;
-        }
-
-        return await handlerDelegate();
+        return wrapper.HandleAsync(request, _serviceProvider, cancellationToken);
     }
 
-    public async Task SendAsync(IRequest request, CancellationToken cancellationToken = default)
+    public Task SendAsync(IRequest request, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(request);
+
         RunValidators(request);
 
-        var requestType = request.GetType();
-        var handlerType = typeof(IRequestHandler<>).MakeGenericType(requestType);
+        var wrapper = VoidRequestHandlerWrappers.GetOrAdd(
+            request.GetType(),
+            static requestType =>
+                (VoidRequestHandlerWrapper)Activator.CreateInstance(typeof(VoidRequestHandlerWrapperImpl<>).MakeGenericType(requestType))!);
 
-        var handler = _serviceProvider.GetService(handlerType);
-        if (handler == null)
-        {
-            throw new InvalidOperationException($"No handler registered for {requestType.Name}");
-        }
-
-        var method = handlerType.GetMethod(nameof(IRequestHandler<IRequest>.HandleAsync));
-        if (method == null)
-        {
-            throw new InvalidOperationException($"HandleAsync method not found on {handlerType.Name}");
-        }
-
-        await (Task)method.Invoke(handler, new object[] { request, cancellationToken })!;
+        return wrapper.HandleAsync(request, _serviceProvider, cancellationToken);
     }
 
-    private void RunValidators<T>(T request)
+    private void RunValidators(object request)
     {
-        var validatorType = typeof(IValidator<>).MakeGenericType(request!.GetType());
-        var validators = _serviceProvider.GetServices(validatorType);
+        var invoker = ValidatorInvokers.GetOrAdd(
+            request.GetType(),
+            static requestType =>
+                (ValidatorInvoker)Activator.CreateInstance(typeof(ValidatorInvokerImpl<>).MakeGenericType(requestType))!);
 
-        var errors = new List<ValidationError>();
-        foreach (var validator in validators)
-        {
-            var validateMethod = validatorType.GetMethod(nameof(IValidator<object>.Validate));
-            if (validateMethod == null)
-                continue;
-
-            var result = validateMethod.Invoke(validator, new object[] { request });
-            if (result is IEnumerable<ValidationError> validationErrors)
-            {
-                errors.AddRange(validationErrors);
-            }
-        }
-
+        var errors = invoker.Validate(request, _serviceProvider);
         if (errors.Count > 0)
-        {
             throw new Validation.ValidationException(errors);
+    }
+
+    private abstract class RequestHandlerWrapper<TResponse>
+    {
+        public abstract Task<TResponse> HandleAsync(IRequest<TResponse> request, IServiceProvider serviceProvider, CancellationToken cancellationToken);
+    }
+
+    private sealed class RequestHandlerWrapperImpl<TRequest, TResponse> : RequestHandlerWrapper<TResponse>
+        where TRequest : IRequest<TResponse>
+    {
+        public override Task<TResponse> HandleAsync(IRequest<TResponse> request, IServiceProvider serviceProvider, CancellationToken cancellationToken)
+        {
+            var handler = serviceProvider.GetService<IRequestHandler<TRequest, TResponse>>()
+                ?? throw new InvalidOperationException($"No handler registered for {typeof(TRequest).Name}");
+
+            var typed = (TRequest)request;
+            RequestHandlerDelegate<TResponse> pipeline = () => handler.HandleAsync(typed, cancellationToken);
+
+            var behaviors = serviceProvider.GetServices<IPipelineBehavior<TRequest, TResponse>>();
+            foreach (var behavior in behaviors.Reverse())
+            {
+                var next = pipeline;
+                pipeline = () => behavior.HandleAsync(typed, next, cancellationToken);
+            }
+
+            return pipeline();
+        }
+    }
+
+    private abstract class VoidRequestHandlerWrapper
+    {
+        public abstract Task HandleAsync(IRequest request, IServiceProvider serviceProvider, CancellationToken cancellationToken);
+    }
+
+    private sealed class VoidRequestHandlerWrapperImpl<TRequest> : VoidRequestHandlerWrapper
+        where TRequest : IRequest
+    {
+        public override Task HandleAsync(IRequest request, IServiceProvider serviceProvider, CancellationToken cancellationToken)
+        {
+            var handler = serviceProvider.GetService<IRequestHandler<TRequest>>()
+                ?? throw new InvalidOperationException($"No handler registered for {typeof(TRequest).Name}");
+            return handler.HandleAsync((TRequest)request, cancellationToken);
+        }
+    }
+
+    private abstract class ValidatorInvoker
+    {
+        public abstract IReadOnlyList<ValidationError> Validate(object request, IServiceProvider serviceProvider);
+    }
+
+    private sealed class ValidatorInvokerImpl<TRequest> : ValidatorInvoker
+    {
+        public override IReadOnlyList<ValidationError> Validate(object request, IServiceProvider serviceProvider)
+        {
+            var validators = serviceProvider.GetServices<IValidator<TRequest>>();
+            List<ValidationError>? errors = null;
+            var typed = (TRequest)request;
+            foreach (var validator in validators)
+            {
+                foreach (var error in validator.Validate(typed))
+                {
+                    (errors ??= []).Add(error);
+                }
+            }
+            return (IReadOnlyList<ValidationError>?)errors ?? Array.Empty<ValidationError>();
         }
     }
 }

--- a/src/StarterApp.Tests/Infrastructure/Mediator/MediatorTests.cs
+++ b/src/StarterApp.Tests/Infrastructure/Mediator/MediatorTests.cs
@@ -99,7 +99,7 @@ public class MediatorTests
     }
 
     [Fact]
-    public async Task SendAsync_void_dispatches_and_skips_validation_on_success()
+    public async Task SendAsync_void_dispatches_to_registered_handler()
     {
         var handler = new VoidHandler();
         var mediator = BuildMediator(s =>
@@ -108,6 +108,26 @@ public class MediatorTests
         await mediator.SendAsync(new VoidRequest());
 
         Assert.True(handler.WasCalled);
+    }
+
+    [Fact]
+    public async Task SendAsync_void_runs_validators_and_throws_ValidationException_on_failure()
+    {
+        var handler = new VoidHandler();
+        var validator = new VoidRequestValidator();
+        var mediator = BuildMediator(s =>
+        {
+            s.AddSingleton<IRequestHandler<VoidRequest>>(handler);
+            s.AddSingleton<IValidator<VoidRequest>>(validator);
+        });
+
+        var ex = await Assert.ThrowsAsync<ValidationException>(
+            () => mediator.SendAsync(new VoidRequest()));
+
+        Assert.True(validator.WasCalled);
+        Assert.False(handler.WasCalled);
+        Assert.Single(ex.Errors);
+        Assert.Equal("void-invalid", ex.Errors[0].ErrorMessage);
     }
 
     private static IMediator BuildMediator(Action<IServiceCollection> configure)
@@ -206,6 +226,16 @@ public class MediatorTests
         {
             WasCalled = true;
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class VoidRequestValidator : IValidator<VoidRequest>
+    {
+        public bool WasCalled { get; private set; }
+        public IEnumerable<ValidationError> Validate(VoidRequest instance)
+        {
+            WasCalled = true;
+            return [new ValidationError("VoidRequest", "void-invalid")];
         }
     }
 }

--- a/src/StarterApp.Tests/Infrastructure/Mediator/MediatorTests.cs
+++ b/src/StarterApp.Tests/Infrastructure/Mediator/MediatorTests.cs
@@ -1,0 +1,211 @@
+using Microsoft.Extensions.DependencyInjection;
+using StarterApp.Api.Infrastructure.Mediator;
+using StarterApp.Api.Infrastructure.Validation;
+using MediatorImpl = StarterApp.Api.Infrastructure.Mediator.Mediator;
+
+namespace StarterApp.Tests.Infrastructure.Mediator;
+
+public class MediatorTests
+{
+    [Fact]
+    public async Task SendAsync_dispatches_to_registered_handler()
+    {
+        var mediator = BuildMediator(s =>
+            s.AddScoped<IRequestHandler<EchoRequest, string>, EchoHandler>());
+
+        var result = await mediator.SendAsync(new EchoRequest("hello"));
+
+        Assert.Equal("handled:hello", result);
+    }
+
+    [Fact]
+    public async Task SendAsync_throws_InvalidOperationException_when_no_handler_registered()
+    {
+        var mediator = BuildMediator(_ => { });
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => mediator.SendAsync(new OrphanRequest()));
+
+        Assert.Contains(nameof(OrphanRequest), ex.Message);
+    }
+
+    [Fact]
+    public async Task SendAsync_runs_pipeline_behaviors_in_registration_order_around_handler()
+    {
+        var log = new List<string>();
+        var mediator = BuildMediator(s =>
+        {
+            s.AddSingleton(log);
+            s.AddScoped<IRequestHandler<OrderedRequest, string>, OrderedHandler>();
+            s.AddScoped<IPipelineBehavior<OrderedRequest, string>, OuterBehavior>();
+            s.AddScoped<IPipelineBehavior<OrderedRequest, string>, InnerBehavior>();
+        });
+
+        var result = await mediator.SendAsync(new OrderedRequest());
+
+        Assert.Equal(["outer-before", "inner-before", "handler", "inner-after", "outer-after"], log);
+        Assert.Equal("ok", result);
+    }
+
+    [Fact]
+    public async Task SendAsync_throws_ValidationException_aggregating_all_validator_errors()
+    {
+        var mediator = BuildMediator(s =>
+        {
+            s.AddScoped<IRequestHandler<ValidatedRequest, string>, ValidatedHandler>();
+            s.AddScoped<IValidator<ValidatedRequest>, FirstFailingValidator>();
+            s.AddScoped<IValidator<ValidatedRequest>, SecondFailingValidator>();
+        });
+
+        var ex = await Assert.ThrowsAsync<ValidationException>(
+            () => mediator.SendAsync(new ValidatedRequest()));
+
+        Assert.Equal(2, ex.Errors.Count);
+        Assert.Contains(ex.Errors, e => e.ErrorMessage == "first");
+        Assert.Contains(ex.Errors, e => e.ErrorMessage == "second");
+    }
+
+    [Fact]
+    public async Task SendAsync_propagates_cancellation_token_to_handler()
+    {
+        CancellationToken captured = default;
+        var mediator = BuildMediator(s =>
+            s.AddScoped<IRequestHandler<TokenRequest, string>>(_ =>
+                new TokenCapturingHandler(ct => captured = ct)));
+
+        using var cts = new CancellationTokenSource();
+        await mediator.SendAsync(new TokenRequest(), cts.Token);
+
+        Assert.Equal(cts.Token, captured);
+    }
+
+    [Fact]
+    public async Task SendAsync_caches_wrapper_and_resolves_handler_per_call_from_DI()
+    {
+        // Regression guard: the wrapper is cached, but the handler must still be
+        // resolved from IServiceProvider on every dispatch so scoped lifetimes and
+        // re-registration work. Two different SPs with different handler instances
+        // for the same request type must both dispatch correctly.
+        var firstMediator = BuildMediator(s =>
+            s.AddScoped<IRequestHandler<EchoRequest, string>>(_ => new EchoHandler("first")));
+        var secondMediator = BuildMediator(s =>
+            s.AddScoped<IRequestHandler<EchoRequest, string>>(_ => new EchoHandler("second")));
+
+        var r1 = await firstMediator.SendAsync(new EchoRequest("x"));
+        var r2 = await secondMediator.SendAsync(new EchoRequest("x"));
+
+        Assert.Equal("first:x", r1);
+        Assert.Equal("second:x", r2);
+    }
+
+    [Fact]
+    public async Task SendAsync_void_dispatches_and_skips_validation_on_success()
+    {
+        var handler = new VoidHandler();
+        var mediator = BuildMediator(s =>
+            s.AddSingleton<IRequestHandler<VoidRequest>>(handler));
+
+        await mediator.SendAsync(new VoidRequest());
+
+        Assert.True(handler.WasCalled);
+    }
+
+    private static IMediator BuildMediator(Action<IServiceCollection> configure)
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<IMediator, MediatorImpl>();
+        configure(services);
+        return services.BuildServiceProvider().GetRequiredService<IMediator>();
+    }
+
+    // --- test doubles ---
+
+    private sealed record EchoRequest(string Payload) : IRequest<string>;
+
+    private sealed class EchoHandler : IRequestHandler<EchoRequest, string>
+    {
+        private readonly string _prefix;
+        public EchoHandler() : this("handled") { }
+        public EchoHandler(string prefix) => _prefix = prefix;
+        public Task<string> HandleAsync(EchoRequest request, CancellationToken cancellationToken)
+            => Task.FromResult($"{_prefix}:{request.Payload}");
+    }
+
+    private sealed record OrphanRequest : IRequest<string>;
+
+    private sealed record OrderedRequest : IRequest<string>;
+
+    private sealed class OrderedHandler(List<string> log) : IRequestHandler<OrderedRequest, string>
+    {
+        public Task<string> HandleAsync(OrderedRequest request, CancellationToken cancellationToken)
+        {
+            log.Add("handler");
+            return Task.FromResult("ok");
+        }
+    }
+
+    private sealed class OuterBehavior(List<string> log) : IPipelineBehavior<OrderedRequest, string>
+    {
+        public async Task<string> HandleAsync(OrderedRequest request, RequestHandlerDelegate<string> next, CancellationToken cancellationToken)
+        {
+            log.Add("outer-before");
+            var result = await next();
+            log.Add("outer-after");
+            return result;
+        }
+    }
+
+    private sealed class InnerBehavior(List<string> log) : IPipelineBehavior<OrderedRequest, string>
+    {
+        public async Task<string> HandleAsync(OrderedRequest request, RequestHandlerDelegate<string> next, CancellationToken cancellationToken)
+        {
+            log.Add("inner-before");
+            var result = await next();
+            log.Add("inner-after");
+            return result;
+        }
+    }
+
+    private sealed record ValidatedRequest : IRequest<string>;
+
+    private sealed class ValidatedHandler : IRequestHandler<ValidatedRequest, string>
+    {
+        public Task<string> HandleAsync(ValidatedRequest request, CancellationToken cancellationToken)
+            => Task.FromResult("unreached");
+    }
+
+    private sealed class FirstFailingValidator : IValidator<ValidatedRequest>
+    {
+        public IEnumerable<ValidationError> Validate(ValidatedRequest instance)
+            => [new ValidationError("x", "first")];
+    }
+
+    private sealed class SecondFailingValidator : IValidator<ValidatedRequest>
+    {
+        public IEnumerable<ValidationError> Validate(ValidatedRequest instance)
+            => [new ValidationError("y", "second")];
+    }
+
+    private sealed record TokenRequest : IRequest<string>;
+
+    private sealed class TokenCapturingHandler(Action<CancellationToken> capture) : IRequestHandler<TokenRequest, string>
+    {
+        public Task<string> HandleAsync(TokenRequest request, CancellationToken cancellationToken)
+        {
+            capture(cancellationToken);
+            return Task.FromResult("ok");
+        }
+    }
+
+    private sealed record VoidRequest : IRequest;
+
+    private sealed class VoidHandler : IRequestHandler<VoidRequest>
+    {
+        public bool WasCalled { get; private set; }
+        public Task HandleAsync(VoidRequest request, CancellationToken cancellationToken)
+        {
+            WasCalled = true;
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces per-call `MakeGenericType` + `MethodInfo.Invoke` in `Mediator` with a wrapper cached per concrete request type (typed, void, and validator paths). First dispatch for a given request type pays the reflection cost once; every subsequent send is a `ConcurrentDictionary` lookup plus a strongly-typed virtual call.
- No more per-call `object[]` argument allocation, no more `GetMethod` lookup per pipeline behavior, no more boxed `Invoke` on the hot path. Public `IMediator` API is unchanged and the DI registration in `AddMediator` is untouched.
- Adds focused unit tests (`MediatorTests.cs`) covering handler dispatch for typed + void requests, missing-handler error path, pipeline behavior ordering, validator error aggregation, cancellation propagation, and cache-doesn't-leak-DI-scope across independent service providers.

## Caveat

This removes reflection from the hot path but keeps the one-time `MakeGenericType` on first dispatch, so it is a strict improvement for JIT-mode apps but still not fully NativeAOT / `PublishAot` safe. Going fully AOT would require a Roslyn source generator that emits closed-generic dispatchers per request type — happy to follow up with that on a separate branch if useful.

## Test plan

- [x] `dotnet build src/StarterApp.Api` — clean
- [x] `dotnet test --filter "FullyQualifiedName!~Integration"` — 253/253 passing (246 pre-existing + 7 new)
- [x] `dotnet test --filter "FullyQualifiedName~MediatorTests"` — 7/7 passing
- [ ] CI (GitHub Actions) green on the PR
- [ ] Spot-check at least one cacheable query end-to-end (e.g. `GET /api/v1/products/{id}`) to confirm the `CachingBehavior` pipeline still fires under the new dispatch path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced message dispatch performance through optimized caching and reduced reflection overhead.
  * Improved validation error aggregation for clearer error reporting.

* **Tests**
  * Added comprehensive test coverage for message dispatch scenarios including handler registration, pipeline behavior execution, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->