### PR TITLE
chore: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 z3d
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- Adds a top-level `LICENSE` file with the MIT License text, `Copyright (c) 2026 z3d`.

## Why

Without a license, the default under copyright law is "all rights reserved" — anyone forking, copying, or learning from the code technically has no permission to do so. Since this repo is framed as a tutorial/starter, an explicit permissive license removes that friction.

MIT chosen because it's the conventional default for permissive open-source .NET starters, is short, and imposes no obligations on consumers beyond attribution. Swap for Apache-2.0 if you want an explicit patent grant, or for a copyleft option (MPL, GPL) if you want derivative works to stay open.

## Test plan

- [x] `LICENSE` file present at repo root with valid MIT text
- [x] GitHub license detector should now show "MIT License" on the repo landing page once merged