### PR TITLE
 Fix Dockerfile CPM regression and add aspire + docker-build CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,12 @@ jobs:
         cache: true
         cache-dependency-path: '**/packages.lock.json'
 
+    - name: Trust ASP.NET Core dev cert
+      run: dotnet dev-certs https --trust
+
+    - name: Install Azure Functions Core Tools
+      run: npm install -g azure-functions-core-tools@4 --unsafe-perm true
+
     - name: Restore dependencies
       run: dotnet restore --force-evaluate
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,41 @@ jobs:
 
     - name: Integration tests
       run: dotnet test --no-build --configuration Release --verbosity normal --filter "FullyQualifiedName~Integration & Category!=Aspire"
+
+  aspire:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '10.0.x'
+        cache: true
+        cache-dependency-path: '**/packages.lock.json'
+
+    - name: Restore dependencies
+      run: dotnet restore --force-evaluate
+
+    - name: Build
+      run: dotnet build --no-restore --configuration Release
+
+    - name: Aspire tests
+      run: dotnet test --no-build --configuration Release --verbosity normal --filter "Category=Aspire"
+
+  docker-build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build migrator image
+      run: docker compose build migrator
+
+    - name: Build api image
+      run: docker compose build api
+
+    - name: Build functions image
+      run: docker compose build functions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,11 @@ jobs:
         cache-dependency-path: '**/packages.lock.json'
 
     - name: Trust ASP.NET Core dev cert
-      run: dotnet dev-certs https --trust
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y libnss3-tools
+        dotnet dev-certs https --trust || true
+        echo "SSL_CERT_DIR=$HOME/.aspnet/dev-certs/trust:/usr/lib/ssl/certs:/etc/ssl/certs" >> "$GITHUB_ENV"
 
     - name: Install Azure Functions Core Tools
       run: npm install -g azure-functions-core-tools@4 --unsafe-perm true

--- a/src/StarterApp.Api/Dockerfile
+++ b/src/StarterApp.Api/Dockerfile
@@ -2,13 +2,18 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
-# Copy Directory.Build.props for shared configuration
+# Copy Directory.Build.props + Directory.Packages.props for shared configuration
+# (CPM requires Directory.Packages.props at restore time)
 COPY ["Directory.Build.props", "Directory.Build.props"]
+COPY ["Directory.Packages.props", "Directory.Packages.props"]
 
-# Copy csproj files first for better layer caching
+# Copy csproj + packages.lock.json files first for better layer caching
 COPY ["src/StarterApp.Api/StarterApp.Api.csproj", "src/StarterApp.Api/"]
+COPY ["src/StarterApp.Api/packages.lock.json", "src/StarterApp.Api/"]
 COPY ["src/StarterApp.Domain/StarterApp.Domain.csproj", "src/StarterApp.Domain/"]
+COPY ["src/StarterApp.Domain/packages.lock.json", "src/StarterApp.Domain/"]
 COPY ["src/StarterApp.ServiceDefaults/StarterApp.ServiceDefaults.csproj", "src/StarterApp.ServiceDefaults/"]
+COPY ["src/StarterApp.ServiceDefaults/packages.lock.json", "src/StarterApp.ServiceDefaults/"]
 
 # Restore dependencies
 RUN dotnet restore "src/StarterApp.Api/StarterApp.Api.csproj"

--- a/src/StarterApp.DbMigrator/Dockerfile
+++ b/src/StarterApp.DbMigrator/Dockerfile
@@ -3,8 +3,11 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 COPY ["Directory.Build.props", "Directory.Build.props"]
+COPY ["Directory.Packages.props", "Directory.Packages.props"]
 COPY ["src/StarterApp.DbMigrator/StarterApp.DbMigrator.csproj", "src/StarterApp.DbMigrator/"]
+COPY ["src/StarterApp.DbMigrator/packages.lock.json", "src/StarterApp.DbMigrator/"]
 COPY ["src/StarterApp.ServiceDefaults/StarterApp.ServiceDefaults.csproj", "src/StarterApp.ServiceDefaults/"]
+COPY ["src/StarterApp.ServiceDefaults/packages.lock.json", "src/StarterApp.ServiceDefaults/"]
 
 RUN dotnet restore "src/StarterApp.DbMigrator/StarterApp.DbMigrator.csproj"
 

--- a/src/StarterApp.Functions/Dockerfile
+++ b/src/StarterApp.Functions/Dockerfile
@@ -2,8 +2,11 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 COPY Directory.Build.props .
+COPY Directory.Packages.props .
 COPY src/StarterApp.Functions/StarterApp.Functions.csproj src/StarterApp.Functions/
+COPY src/StarterApp.Functions/packages.lock.json src/StarterApp.Functions/
 COPY src/StarterApp.ServiceDefaults/StarterApp.ServiceDefaults.csproj src/StarterApp.ServiceDefaults/
+COPY src/StarterApp.ServiceDefaults/packages.lock.json src/StarterApp.ServiceDefaults/
 RUN dotnet restore src/StarterApp.Functions/StarterApp.Functions.csproj
 
 COPY src/StarterApp.Functions/ src/StarterApp.Functions/


### PR DESCRIPTION
Central Package Management requires Directory.Packages.props at restore time. The Dockerfiles only copied Directory.Build.props, so container builds failed with NU1015 ("PackageReference without version"). Copy Directory.Packages.props and all packages.lock.json files before dotnet restore in each service image.

Add two CI jobs to catch regressions earlier:
- aspire: runs DistributedApplicationTestingBuilder tests (Category=Aspire), previously excluded from the integration job
- docker-build: builds migrator, api, and functions images via docker compose (would have caught the CPM regression above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with additional Aspire test suite execution
  * Added Docker Compose service builds (API, database migrator, functions) to the pipeline
  * Optimized Docker build layer caching across services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->