### PR TITLE
Bump Aspire packages to 13.2.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,14 +12,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.2.1" />
-    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.2.1" />
-    <PackageVersion Include="Aspire.Hosting.DevTunnels" Version="13.2.1" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.2.1" />
-    <PackageVersion Include="Aspire.Hosting.Seq" Version="13.2.1" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.2.1" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.2.1" />
-    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.2.1" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.2.3" />
+    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.2.3" />
+    <PackageVersion Include="Aspire.Hosting.DevTunnels" Version="13.2.3" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.2.3" />
+    <PackageVersion Include="Aspire.Hosting.Seq" Version="13.2.3" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.2.3" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.2.3" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.2.3" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageVersion Include="Best.Conventional" Version="12.0.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />

--- a/src/StarterApp.Api/packages.lock.json
+++ b/src/StarterApp.Api/packages.lock.json
@@ -4,12 +4,12 @@
     "net10.0": {
       "Aspire.StackExchange.Redis.DistributedCaching": {
         "type": "Direct",
-        "requested": "[13.2.1, )",
-        "resolved": "13.2.1",
-        "contentHash": "R35H67djP9RFpuKdhZDs1/qS0Fu+nm/UQ7DwpQi8A5XO5CnE2xk7uEoZL7U0ZapXko1ZakIKapPhKcuDJ8tJAg==",
+        "requested": "[13.2.3, )",
+        "resolved": "13.2.3",
+        "contentHash": "7Ivsa1fRT2waAQ/Fj7QnkC6aI1hBS5LKirbRfPNtxT00AxHIQI8dZryW9J4rNOLPqDdjndf1tMYrQQ+HafzQaQ==",
         "dependencies": {
           "AspNetCore.HealthChecks.Redis": "9.0.0",
-          "Aspire.StackExchange.Redis": "13.2.1",
+          "Aspire.StackExchange.Redis": "13.2.3",
           "Microsoft.Extensions.Caching.StackExchangeRedis": "10.0.5",
           "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.2.0",
           "OpenTelemetry.Extensions.Hosting": "1.15.0",
@@ -122,8 +122,8 @@
       },
       "Aspire.StackExchange.Redis": {
         "type": "Transitive",
-        "resolved": "13.2.1",
-        "contentHash": "V7tatWoJj5HPa6oolIDVEQg73rhiRFi7l8gyE7/QOkroKa31mpN1eYfNs3JQrkco8LbL84bcjXYv0ErE0oWIjw==",
+        "resolved": "13.2.3",
+        "contentHash": "ZBfP8yv6/9VbrRad2j0xtbXPB2RzpOgToQQKuhOqvPhwRppZ8/YlqkTOb4uWqNHl9U3+MkeWL2OkJ3Tn5kD6Zw==",
         "dependencies": {
           "AspNetCore.HealthChecks.Redis": "9.0.0",
           "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.2.0",

--- a/src/StarterApp.AppHost.Tests/packages.lock.json
+++ b/src/StarterApp.AppHost.Tests/packages.lock.json
@@ -4,13 +4,13 @@
     "net10.0": {
       "Aspire.Hosting.Testing": {
         "type": "Direct",
-        "requested": "[13.2.1, )",
-        "resolved": "13.2.1",
-        "contentHash": "FN9uwrIn0g8SVMLFIpwdtxHYkCBMOcBszbSIqhl1nX/kQVCO/JLcStALFgjo9Sc6DhmwFNakGlOYN7hJ0rWl8Q==",
+        "requested": "[13.2.3, )",
+        "resolved": "13.2.3",
+        "contentHash": "ECmgkNmYQ+u3iixyQaHjJJjwOukX8kRRVYQLvJ+vvtgT+c03kmm5A8LJ+roFr1G/merc3GrquQBcFbdzTxTVxw==",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "9.0.0",
-          "Aspire.Hosting": "13.2.1",
-          "Aspire.Hosting.AppHost": "13.2.1",
+          "Aspire.Hosting": "13.2.3",
+          "Aspire.Hosting.AppHost": "13.2.3",
           "Google.Protobuf": "3.33.5",
           "Grpc.AspNetCore": "2.76.0",
           "Grpc.Net.ClientFactory": "2.76.0",
@@ -94,19 +94,18 @@
       },
       "Aspire.Dashboard.Sdk.osx-arm64": {
         "type": "Transitive",
-        "resolved": "13.2.1",
-        "contentHash": "TDkX+NUOi4PRlwSdrlhoZaQADVWbIzRbPvQ+uinocV8PZk0F3l22pz7GXCSg0ltd9k+qVE23EXsUzf+AOk7iYg=="
+        "resolved": "13.2.3",
+        "contentHash": "DYIrHUB0RD7l46iaFb7DAfbF9+juUbAh0SLWW78/S+IFB5K0PaBDeGNUTaiqiTNqTviragQsWtsepR4uf5Df2A=="
       },
       "Aspire.Hosting": {
         "type": "Transitive",
-        "resolved": "13.2.1",
-        "contentHash": "GY/T5iK2F4K3Sk60VUeVnTX1MhCjSaX48+qPUjA/rI1x1ONHevHzFj+Gc3fNlGEaZGY8L87hSxwGrV+Bjd5EJw==",
+        "resolved": "13.2.3",
+        "contentHash": "ZxeA65QIaNZRayYtoPpfNS2o4Fwh+mWkKyzyN6KFh1A97z5VG1oI4A/AFgF+XaUT/dOhC/8itfeaaUtvQoGPsQ==",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "9.0.0",
           "Google.Protobuf": "3.33.5",
           "Grpc.AspNetCore": "2.76.0",
           "Grpc.Net.ClientFactory": "2.76.0",
-          "Grpc.Tools": "2.78.0",
           "Humanizer.Core": "2.14.1",
           "JsonPatch.Net": "3.3.0",
           "KubernetesClient": "18.0.13",
@@ -131,11 +130,11 @@
       },
       "Aspire.Hosting.Azure": {
         "type": "Transitive",
-        "resolved": "13.2.1",
-        "contentHash": "rFWg9D2lZJ0XBJ6VAFKxScL+tcmQyV4k6XDNKExVoORb8tkDWYIU3pmbKxEanw50jGpkbr1XiX08V2x9KrSkGw==",
+        "resolved": "13.2.3",
+        "contentHash": "/6b9Y+Ix7D/obL7BK0MryOWcEqwXzYU7MHS5vR1UHDcgcKezNu+RIdHyg+8BgPJswEyxdZkgx3pLo5t+XAUMbg==",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "9.0.0",
-          "Aspire.Hosting": "13.2.1",
+          "Aspire.Hosting": "13.2.3",
           "Azure.Core": "1.51.1",
           "Azure.Identity": "1.18.0",
           "Azure.Provisioning": "1.5.0",
@@ -170,8 +169,8 @@
       },
       "Aspire.Hosting.Orchestration.osx-arm64": {
         "type": "Transitive",
-        "resolved": "13.2.1",
-        "contentHash": "OPCLoxS/tcoR9DFyNQ2SPQ5R5JgnIWS9ANrokoaxYs1AFIeAbfgfLWcVpw107ZZUr47bKsqnD4WpFTRJm/UZMQ=="
+        "resolved": "13.2.3",
+        "contentHash": "V7rl12Jf3A92Uj7hpDdvHG2/qF/fanA8DXdnadus5bqA4om8eRTIwsGdIKZeyvqCpIORrhuP49LfSh/9r1r9FQ=="
       },
       "AspNetCore.HealthChecks.Redis": {
         "type": "Transitive",
@@ -1090,24 +1089,24 @@
       "starterapp.apphost": {
         "type": "Project",
         "dependencies": {
-          "Aspire.Dashboard.Sdk.osx-arm64": "[13.2.1, )",
-          "Aspire.Hosting.AppHost": "[13.2.1, )",
-          "Aspire.Hosting.Azure.ServiceBus": "[13.2.1, )",
-          "Aspire.Hosting.DevTunnels": "[13.2.1, )",
-          "Aspire.Hosting.Orchestration.osx-arm64": "[13.2.1, )",
-          "Aspire.Hosting.Redis": "[13.2.1, )",
-          "Aspire.Hosting.Seq": "[13.2.1, )",
-          "Aspire.Hosting.SqlServer": "[13.2.1, )"
+          "Aspire.Dashboard.Sdk.osx-arm64": "[13.2.3, )",
+          "Aspire.Hosting.AppHost": "[13.2.3, )",
+          "Aspire.Hosting.Azure.ServiceBus": "[13.2.3, )",
+          "Aspire.Hosting.DevTunnels": "[13.2.3, )",
+          "Aspire.Hosting.Orchestration.osx-arm64": "[13.2.3, )",
+          "Aspire.Hosting.Redis": "[13.2.3, )",
+          "Aspire.Hosting.Seq": "[13.2.3, )",
+          "Aspire.Hosting.SqlServer": "[13.2.3, )"
         }
       },
       "Aspire.Hosting.AppHost": {
         "type": "CentralTransitive",
-        "requested": "[13.2.1, )",
-        "resolved": "13.2.1",
-        "contentHash": "4B/eoZPwOobxpMpvYnqe/EcXabjPhZJhfxlHXv5gdKd16duoWbHnvvAZJsVI3WUpakCwmsCiTrT4sNGfW8H+IQ==",
+        "requested": "[13.2.3, )",
+        "resolved": "13.2.3",
+        "contentHash": "DzBXtZ70d3kh778hOdYwsFj18deB5XTH8RUs9XKrlAej8AX42oUKkz6Kalc8L+YuCYDhBEu21dxaOqG92mq7fw==",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "9.0.0",
-          "Aspire.Hosting": "13.2.1",
+          "Aspire.Hosting": "13.2.3",
           "Google.Protobuf": "3.33.5",
           "Grpc.AspNetCore": "2.76.0",
           "Grpc.Net.ClientFactory": "2.76.0",
@@ -1136,12 +1135,12 @@
       },
       "Aspire.Hosting.Azure.ServiceBus": {
         "type": "CentralTransitive",
-        "requested": "[13.2.1, )",
-        "resolved": "13.2.1",
-        "contentHash": "1HwvdHi5/Fm2lhfFMYecqbTRTvItqnU7QUopA94uPH9ED/52Utb0+YEkFWhPJQa+hWobO6ERsBcLVnnqtefsLg==",
+        "requested": "[13.2.3, )",
+        "resolved": "13.2.3",
+        "contentHash": "4bGDLqd2/6B+QW3if7AZDG3Qu8ib0wQ0hGGN82CYEI5O5Ct3XtUn9lI/5ptN5jHTGAhh8tlhNmAiaaWtUIidEA==",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "9.0.0",
-          "Aspire.Hosting.Azure": "13.2.1",
+          "Aspire.Hosting.Azure": "13.2.3",
           "Azure.Core": "1.51.1",
           "Azure.Identity": "1.18.0",
           "Azure.Provisioning": "1.5.0",
@@ -1177,12 +1176,12 @@
       },
       "Aspire.Hosting.DevTunnels": {
         "type": "CentralTransitive",
-        "requested": "[13.2.1, )",
-        "resolved": "13.2.1",
-        "contentHash": "bymNP9ikEs0+PqRYp9WBGJ46sB9EzMhAy6Ty5jRd9Ridg3HHQfStppXWW6kOhBZQgPXD6S8wMeH0Ibiq+C6wbA==",
+        "requested": "[13.2.3, )",
+        "resolved": "13.2.3",
+        "contentHash": "ZOYOf6cJmcxdOgmDFS5TJTX1jtxplhAR8WNbDqJYjzZ/6a/4kP6wc2iiA75bcdNtq1Y2o6q+8bEwW6VZ5nzo6A==",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "9.0.0",
-          "Aspire.Hosting": "13.2.1",
+          "Aspire.Hosting": "13.2.3",
           "Google.Protobuf": "3.33.5",
           "Grpc.AspNetCore": "2.76.0",
           "Grpc.Net.ClientFactory": "2.76.0",
@@ -1211,13 +1210,13 @@
       },
       "Aspire.Hosting.Redis": {
         "type": "CentralTransitive",
-        "requested": "[13.2.1, )",
-        "resolved": "13.2.1",
-        "contentHash": "cbFWW8MYGlxEyvesrJTY4rWxgdT9NsMC/WrXW2U0bT4XYk7YiJzk/lds6HeNIdW5AOG0m/QejbmqYWIc/Ek0tA==",
+        "requested": "[13.2.3, )",
+        "resolved": "13.2.3",
+        "contentHash": "dcmR113sMBiqkNBe9nwrwIexru3OZloWam07EnmVRanrstwv00QH2yWUaMxng/9hHs9jLcYsylEXZmdzCsN0Sg==",
         "dependencies": {
           "AspNetCore.HealthChecks.Redis": "9.0.0",
           "AspNetCore.HealthChecks.Uris": "9.0.0",
-          "Aspire.Hosting": "13.2.1",
+          "Aspire.Hosting": "13.2.3",
           "Google.Protobuf": "3.33.5",
           "Grpc.AspNetCore": "2.76.0",
           "Grpc.Net.ClientFactory": "2.76.0",
@@ -1247,12 +1246,12 @@
       },
       "Aspire.Hosting.Seq": {
         "type": "CentralTransitive",
-        "requested": "[13.2.1, )",
-        "resolved": "13.2.1",
-        "contentHash": "Lh/B9NuNCts6X6xVLqBQJKoUUmULEBQugrqzkPateuNR5xl4bZ+LTAFyR16NqpxbtdXhFAU1o2ALtk+qGGsPyw==",
+        "requested": "[13.2.3, )",
+        "resolved": "13.2.3",
+        "contentHash": "21R/5H0g6whB2HbPRuiK93Cins+6/k0PgDaelgFWqyFmCIBesrDENyixA7URgG/jqLuwsWmsWexk80EAy/kB+g==",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "9.0.0",
-          "Aspire.Hosting": "13.2.1",
+          "Aspire.Hosting": "13.2.3",
           "Google.Protobuf": "3.33.5",
           "Grpc.AspNetCore": "2.76.0",
           "Grpc.Net.ClientFactory": "2.76.0",
@@ -1281,13 +1280,13 @@
       },
       "Aspire.Hosting.SqlServer": {
         "type": "CentralTransitive",
-        "requested": "[13.2.1, )",
-        "resolved": "13.2.1",
-        "contentHash": "TQVnbyYChei4CPk7fz5zd6f44mdXIBvrsG7VAOM6WojgcKK4p1qgGKGFcA/Jy0DLdXNDkl5PeeCl1w7Elshi1g==",
+        "requested": "[13.2.3, )",
+        "resolved": "13.2.3",
+        "contentHash": "lQfxeSvNeSHi2UWvEd9J0q6P6F8bBKXQSyAnJh7KepNcZg1vcATADLnlv/gcHLWjhKsCnxWQaf5O3EFIN652og==",
         "dependencies": {
           "AspNetCore.HealthChecks.SqlServer": "9.0.0",
           "AspNetCore.HealthChecks.Uris": "9.0.0",
-          "Aspire.Hosting": "13.2.1",
+          "Aspire.Hosting": "13.2.3",
           "Azure.Core": "1.51.1",
           "Azure.Identity": "1.18.0",
           "Google.Protobuf": "3.33.5",

--- a/src/StarterApp.AppHost/packages.lock.json
+++ b/src/StarterApp.AppHost/packages.lock.json
@@ -4,18 +4,18 @@
     "net10.0": {
       "Aspire.Dashboard.Sdk.osx-arm64": {
         "type": "Direct",
-        "requested": "[13.2.1, )",
-        "resolved": "13.2.1",
-        "contentHash": "TDkX+NUOi4PRlwSdrlhoZaQADVWbIzRbPvQ+uinocV8PZk0F3l22pz7GXCSg0ltd9k+qVE23EXsUzf+AOk7iYg=="
+        "requested": "[13.2.3, )",
+        "resolved": "13.2.3",
+        "contentHash": "DYIrHUB0RD7l46iaFb7DAfbF9+juUbAh0SLWW78/S+IFB5K0PaBDeGNUTaiqiTNqTviragQsWtsepR4uf5Df2A=="
       },
       "Aspire.Hosting.AppHost": {
         "type": "Direct",
-        "requested": "[13.2.1, )",
-        "resolved": "13.2.1",
-        "contentHash": "4B/eoZPwOobxpMpvYnqe/EcXabjPhZJhfxlHXv5gdKd16duoWbHnvvAZJsVI3WUpakCwmsCiTrT4sNGfW8H+IQ==",
+        "requested": "[13.2.3, )",
+        "resolved": "13.2.3",
+        "contentHash": "DzBXtZ70d3kh778hOdYwsFj18deB5XTH8RUs9XKrlAej8AX42oUKkz6Kalc8L+YuCYDhBEu21dxaOqG92mq7fw==",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "9.0.0",
-          "Aspire.Hosting": "13.2.1",
+          "Aspire.Hosting": "13.2.3",
           "Google.Protobuf": "3.33.5",
           "Grpc.AspNetCore": "2.76.0",
           "Grpc.Net.ClientFactory": "2.76.0",
@@ -44,12 +44,12 @@
       },
       "Aspire.Hosting.Azure.ServiceBus": {
         "type": "Direct",
-        "requested": "[13.2.1, )",
-        "resolved": "13.2.1",
-        "contentHash": "1HwvdHi5/Fm2lhfFMYecqbTRTvItqnU7QUopA94uPH9ED/52Utb0+YEkFWhPJQa+hWobO6ERsBcLVnnqtefsLg==",
+        "requested": "[13.2.3, )",
+        "resolved": "13.2.3",
+        "contentHash": "4bGDLqd2/6B+QW3if7AZDG3Qu8ib0wQ0hGGN82CYEI5O5Ct3XtUn9lI/5ptN5jHTGAhh8tlhNmAiaaWtUIidEA==",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "9.0.0",
-          "Aspire.Hosting.Azure": "13.2.1",
+          "Aspire.Hosting.Azure": "13.2.3",
           "Azure.Core": "1.51.1",
           "Azure.Identity": "1.18.0",
           "Azure.Provisioning": "1.5.0",
@@ -85,12 +85,12 @@
       },
       "Aspire.Hosting.DevTunnels": {
         "type": "Direct",
-        "requested": "[13.2.1, )",
-        "resolved": "13.2.1",
-        "contentHash": "bymNP9ikEs0+PqRYp9WBGJ46sB9EzMhAy6Ty5jRd9Ridg3HHQfStppXWW6kOhBZQgPXD6S8wMeH0Ibiq+C6wbA==",
+        "requested": "[13.2.3, )",
+        "resolved": "13.2.3",
+        "contentHash": "ZOYOf6cJmcxdOgmDFS5TJTX1jtxplhAR8WNbDqJYjzZ/6a/4kP6wc2iiA75bcdNtq1Y2o6q+8bEwW6VZ5nzo6A==",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "9.0.0",
-          "Aspire.Hosting": "13.2.1",
+          "Aspire.Hosting": "13.2.3",
           "Google.Protobuf": "3.33.5",
           "Grpc.AspNetCore": "2.76.0",
           "Grpc.Net.ClientFactory": "2.76.0",
@@ -119,19 +119,19 @@
       },
       "Aspire.Hosting.Orchestration.osx-arm64": {
         "type": "Direct",
-        "requested": "[13.2.1, )",
-        "resolved": "13.2.1",
-        "contentHash": "OPCLoxS/tcoR9DFyNQ2SPQ5R5JgnIWS9ANrokoaxYs1AFIeAbfgfLWcVpw107ZZUr47bKsqnD4WpFTRJm/UZMQ=="
+        "requested": "[13.2.3, )",
+        "resolved": "13.2.3",
+        "contentHash": "V7rl12Jf3A92Uj7hpDdvHG2/qF/fanA8DXdnadus5bqA4om8eRTIwsGdIKZeyvqCpIORrhuP49LfSh/9r1r9FQ=="
       },
       "Aspire.Hosting.Redis": {
         "type": "Direct",
-        "requested": "[13.2.1, )",
-        "resolved": "13.2.1",
-        "contentHash": "cbFWW8MYGlxEyvesrJTY4rWxgdT9NsMC/WrXW2U0bT4XYk7YiJzk/lds6HeNIdW5AOG0m/QejbmqYWIc/Ek0tA==",
+        "requested": "[13.2.3, )",
+        "resolved": "13.2.3",
+        "contentHash": "dcmR113sMBiqkNBe9nwrwIexru3OZloWam07EnmVRanrstwv00QH2yWUaMxng/9hHs9jLcYsylEXZmdzCsN0Sg==",
         "dependencies": {
           "AspNetCore.HealthChecks.Redis": "9.0.0",
           "AspNetCore.HealthChecks.Uris": "9.0.0",
-          "Aspire.Hosting": "13.2.1",
+          "Aspire.Hosting": "13.2.3",
           "Google.Protobuf": "3.33.5",
           "Grpc.AspNetCore": "2.76.0",
           "Grpc.Net.ClientFactory": "2.76.0",
@@ -161,12 +161,12 @@
       },
       "Aspire.Hosting.Seq": {
         "type": "Direct",
-        "requested": "[13.2.1, )",
-        "resolved": "13.2.1",
-        "contentHash": "Lh/B9NuNCts6X6xVLqBQJKoUUmULEBQugrqzkPateuNR5xl4bZ+LTAFyR16NqpxbtdXhFAU1o2ALtk+qGGsPyw==",
+        "requested": "[13.2.3, )",
+        "resolved": "13.2.3",
+        "contentHash": "21R/5H0g6whB2HbPRuiK93Cins+6/k0PgDaelgFWqyFmCIBesrDENyixA7URgG/jqLuwsWmsWexk80EAy/kB+g==",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "9.0.0",
-          "Aspire.Hosting": "13.2.1",
+          "Aspire.Hosting": "13.2.3",
           "Google.Protobuf": "3.33.5",
           "Grpc.AspNetCore": "2.76.0",
           "Grpc.Net.ClientFactory": "2.76.0",
@@ -195,13 +195,13 @@
       },
       "Aspire.Hosting.SqlServer": {
         "type": "Direct",
-        "requested": "[13.2.1, )",
-        "resolved": "13.2.1",
-        "contentHash": "TQVnbyYChei4CPk7fz5zd6f44mdXIBvrsG7VAOM6WojgcKK4p1qgGKGFcA/Jy0DLdXNDkl5PeeCl1w7Elshi1g==",
+        "requested": "[13.2.3, )",
+        "resolved": "13.2.3",
+        "contentHash": "lQfxeSvNeSHi2UWvEd9J0q6P6F8bBKXQSyAnJh7KepNcZg1vcATADLnlv/gcHLWjhKsCnxWQaf5O3EFIN652og==",
         "dependencies": {
           "AspNetCore.HealthChecks.SqlServer": "9.0.0",
           "AspNetCore.HealthChecks.Uris": "9.0.0",
-          "Aspire.Hosting": "13.2.1",
+          "Aspire.Hosting": "13.2.3",
           "Azure.Core": "1.51.1",
           "Azure.Identity": "1.18.0",
           "Google.Protobuf": "3.33.5",
@@ -241,14 +241,13 @@
       },
       "Aspire.Hosting": {
         "type": "Transitive",
-        "resolved": "13.2.1",
-        "contentHash": "GY/T5iK2F4K3Sk60VUeVnTX1MhCjSaX48+qPUjA/rI1x1ONHevHzFj+Gc3fNlGEaZGY8L87hSxwGrV+Bjd5EJw==",
+        "resolved": "13.2.3",
+        "contentHash": "ZxeA65QIaNZRayYtoPpfNS2o4Fwh+mWkKyzyN6KFh1A97z5VG1oI4A/AFgF+XaUT/dOhC/8itfeaaUtvQoGPsQ==",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "9.0.0",
           "Google.Protobuf": "3.33.5",
           "Grpc.AspNetCore": "2.76.0",
           "Grpc.Net.ClientFactory": "2.76.0",
-          "Grpc.Tools": "2.78.0",
           "Humanizer.Core": "2.14.1",
           "JsonPatch.Net": "3.3.0",
           "KubernetesClient": "18.0.13",
@@ -273,11 +272,11 @@
       },
       "Aspire.Hosting.Azure": {
         "type": "Transitive",
-        "resolved": "13.2.1",
-        "contentHash": "rFWg9D2lZJ0XBJ6VAFKxScL+tcmQyV4k6XDNKExVoORb8tkDWYIU3pmbKxEanw50jGpkbr1XiX08V2x9KrSkGw==",
+        "resolved": "13.2.3",
+        "contentHash": "/6b9Y+Ix7D/obL7BK0MryOWcEqwXzYU7MHS5vR1UHDcgcKezNu+RIdHyg+8BgPJswEyxdZkgx3pLo5t+XAUMbg==",
         "dependencies": {
           "AspNetCore.HealthChecks.Uris": "9.0.0",
-          "Aspire.Hosting": "13.2.1",
+          "Aspire.Hosting": "13.2.3",
           "Azure.Core": "1.51.1",
           "Azure.Identity": "1.18.0",
           "Azure.Provisioning": "1.5.0",

--- a/src/StarterApp.Tests/packages.lock.json
+++ b/src/StarterApp.Tests/packages.lock.json
@@ -204,8 +204,8 @@
       },
       "Aspire.StackExchange.Redis": {
         "type": "Transitive",
-        "resolved": "13.2.1",
-        "contentHash": "V7tatWoJj5HPa6oolIDVEQg73rhiRFi7l8gyE7/QOkroKa31mpN1eYfNs3JQrkco8LbL84bcjXYv0ErE0oWIjw==",
+        "resolved": "13.2.3",
+        "contentHash": "ZBfP8yv6/9VbrRad2j0xtbXPB2RzpOgToQQKuhOqvPhwRppZ8/YlqkTOb4uWqNHl9U3+MkeWL2OkJ3Tn5kD6Zw==",
         "dependencies": {
           "AspNetCore.HealthChecks.Redis": "9.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
@@ -1149,7 +1149,7 @@
       "starterapp.api": {
         "type": "Project",
         "dependencies": {
-          "Aspire.StackExchange.Redis.DistributedCaching": "[13.2.1, )",
+          "Aspire.StackExchange.Redis.DistributedCaching": "[13.2.3, )",
           "Azure.Messaging.ServiceBus": "[7.20.1, )",
           "Dapper": "[2.1.35, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.3, )",
@@ -1199,12 +1199,12 @@
       },
       "Aspire.StackExchange.Redis.DistributedCaching": {
         "type": "CentralTransitive",
-        "requested": "[13.2.1, )",
-        "resolved": "13.2.1",
-        "contentHash": "R35H67djP9RFpuKdhZDs1/qS0Fu+nm/UQ7DwpQi8A5XO5CnE2xk7uEoZL7U0ZapXko1ZakIKapPhKcuDJ8tJAg==",
+        "requested": "[13.2.3, )",
+        "resolved": "13.2.3",
+        "contentHash": "7Ivsa1fRT2waAQ/Fj7QnkC6aI1hBS5LKirbRfPNtxT00AxHIQI8dZryW9J4rNOLPqDdjndf1tMYrQQ+HafzQaQ==",
         "dependencies": {
           "AspNetCore.HealthChecks.Redis": "9.0.0",
-          "Aspire.StackExchange.Redis": "13.2.1",
+          "Aspire.StackExchange.Redis": "13.2.3",
           "Microsoft.Extensions.Caching.StackExchangeRedis": "10.0.5",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
           "Microsoft.Extensions.Configuration.Binder": "10.0.5",


### PR DESCRIPTION
## Summary
- Updates all `Aspire.*` package versions in `Directory.Packages.props` from 13.2.1 to 13.2.3 (latest stable)
- Refreshes `packages.lock.json` across affected projects

## Test plan
- [x] `dotnet restore --force-evaluate`
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 335/335 passing (331 unit/integration + 4 AppHost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)