### PR TITLE
test: shared Aspire E2E fixture (complexity-review backlog item 13)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -94,8 +94,9 @@ survives sessions; each item is marked done with its commit, same discipline as 
 11. [x] `[FeatureToggle("order-placement")]` exemplar — DONE (same commit as item 5).
 12. [x] `amr` signed as a first-class field; projected-header hash deleted — DONE (same commit
     as item 6). Tampered `X-Authenticated-Amr` now fails against the signature like scopes.
-13. [ ] Shared Aspire E2E fixture: one distributed-app boot instead of five in
-    `OutboxToServiceBusIntegrationTests`.
+13. [x] Shared Aspire E2E fixture — DONE (commit "test: boot the distributed app once for the
+    Aspire E2E collection"); 5 boots → 1, verified by the CI aspire job (local Docker was
+    unavailable; see commit message).
 14. [x] Review-doc compaction — DONE (commit "docs: compact the architecture review to living
     state; archive the narrative history"). Living doc ~100 lines; archive verbatim under
     docs/reviews/; DONE bodies collapsed; stale review-skill score and skill-authoring

--- a/src/StarterApp.AppHost.Tests/AspireE2EFixture.cs
+++ b/src/StarterApp.AppHost.Tests/AspireE2EFixture.cs
@@ -26,9 +26,14 @@ public sealed class AspireE2EFixture : IAsyncLifetime
             await App.DisposeAsync();
     }
 
+    // No identity headers: orchestrator probes (Docker, Kubernetes) carry none, so health
+    // endpoints must be verifiable anonymously — an authenticated-only client would mask a
+    // regression that accidentally puts gateway identity in front of readiness/liveness.
+    public HttpClient CreateAnonymousApiClient() => App.CreateHttpClient("api");
+
     public HttpClient CreateApiClient()
     {
-        var client = App.CreateHttpClient("api");
+        var client = CreateAnonymousApiClient();
         client.DefaultRequestHeaders.Add("X-Authenticated-Subject", "apphost-test-user");
         client.DefaultRequestHeaders.Add("X-Authenticated-Principal-Type", "User");
         client.DefaultRequestHeaders.Add("X-Authenticated-Tenant-Id", "apphost-test-tenant");

--- a/src/StarterApp.AppHost.Tests/AspireE2EFixture.cs
+++ b/src/StarterApp.AppHost.Tests/AspireE2EFixture.cs
@@ -1,0 +1,42 @@
+using Aspire.Hosting;
+using Aspire.Hosting.Testing;
+
+namespace StarterApp.AppHost.Tests;
+
+// One distributed-app boot for the whole E2E collection. Booting per test multiplied the
+// documented Service Bus emulator flake surface by the number of facts (the watch-item in
+// docs/ARCHITECTURE_REVIEW.md) and paid ~4 cold starts of pure overhead; isolation between
+// facts is already structural — every test correlates by its own ids (GUID emails, order ids,
+// correlation ids), never by global state.
+public sealed class AspireE2EFixture : IAsyncLifetime
+{
+    public DistributedApplication App { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        var appHost = await DistributedApplicationTestingBuilder
+            .CreateAsync<Projects.StarterApp_AppHost>();
+        App = await appHost.BuildAsync();
+        await App.StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (App is not null)
+            await App.DisposeAsync();
+    }
+
+    public HttpClient CreateApiClient()
+    {
+        var client = App.CreateHttpClient("api");
+        client.DefaultRequestHeaders.Add("X-Authenticated-Subject", "apphost-test-user");
+        client.DefaultRequestHeaders.Add("X-Authenticated-Principal-Type", "User");
+        client.DefaultRequestHeaders.Add("X-Authenticated-Tenant-Id", "apphost-test-tenant");
+        client.DefaultRequestHeaders.Add("X-Authenticated-Scopes", "customers:read customers:write orders:read orders:write products:read products:write");
+        client.DefaultRequestHeaders.Add("X-Authenticated-Amr", "mfa pwd");
+        return client;
+    }
+}
+
+[CollectionDefinition("Aspire E2E")]
+public sealed class AspireE2ECollection : ICollectionFixture<AspireE2EFixture>;

--- a/src/StarterApp.AppHost.Tests/OutboxToServiceBusIntegrationTests.cs
+++ b/src/StarterApp.AppHost.Tests/OutboxToServiceBusIntegrationTests.cs
@@ -8,41 +8,25 @@ using Npgsql;
 
 namespace StarterApp.AppHost.Tests;
 
+[Collection("Aspire E2E")]
 [Trait("Category", "Aspire")]
 public class OutboxToServiceBusIntegrationTests
 {
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-    [Fact]
-    public async Task AppHost_ShouldEventuallyExposeHealthyApi()
+    private readonly AspireE2EFixture _fixture;
+
+    public OutboxToServiceBusIntegrationTests(AspireE2EFixture fixture)
     {
-        // Arrange
-        var appHost = await DistributedApplicationTestingBuilder
-            .CreateAsync<Projects.StarterApp_AppHost>();
-        await using var app = await appHost.BuildAsync();
-        await app.StartAsync();
-
-        var httpClient = app.CreateHttpClient("api");
-        ConfigureGatewayIdentity(httpClient);
-
-        // Act — poll with retries instead of a single GET, since resources may still be starting
-        var response = await PollForHealthyAsync(httpClient, "/health/live");
-
-        // Assert
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        _fixture = fixture;
     }
 
     [Fact]
     public async Task CreateOrder_ShouldSucceedEndToEnd()
     {
         // Arrange
-        var appHost = await DistributedApplicationTestingBuilder
-            .CreateAsync<Projects.StarterApp_AppHost>();
-        await using var app = await appHost.BuildAsync();
-        await app.StartAsync();
-
-        var httpClient = app.CreateHttpClient("api");
-        ConfigureGatewayIdentity(httpClient);
+        var app = _fixture.App;
+        var httpClient = _fixture.CreateApiClient();
 
         // Wait for API to be ready
         await PollForHealthyAsync(httpClient, "/health/ready");
@@ -98,13 +82,8 @@ public class OutboxToServiceBusIntegrationTests
     public async Task HealthEndpoints_ShouldBeReachable()
     {
         // Arrange
-        var appHost = await DistributedApplicationTestingBuilder
-            .CreateAsync<Projects.StarterApp_AppHost>();
-        await using var app = await appHost.BuildAsync();
-        await app.StartAsync();
-
-        var httpClient = app.CreateHttpClient("api");
-        ConfigureGatewayIdentity(httpClient);
+        var app = _fixture.App;
+        var httpClient = _fixture.CreateApiClient();
 
         // Wait for full readiness before checking all endpoints
         await PollForHealthyAsync(httpClient, "/health/ready");
@@ -124,13 +103,8 @@ public class OutboxToServiceBusIntegrationTests
     public async Task CreateOrder_ShouldWriteAndProcessOutboxEvent()
     {
         // Arrange
-        var appHost = await DistributedApplicationTestingBuilder
-            .CreateAsync<Projects.StarterApp_AppHost>();
-        await using var app = await appHost.BuildAsync();
-        await app.StartAsync();
-
-        var httpClient = app.CreateHttpClient("api");
-        ConfigureGatewayIdentity(httpClient);
+        var app = _fixture.App;
+        var httpClient = _fixture.CreateApiClient();
         await PollForHealthyAsync(httpClient, "/health/ready");
 
         // Create a customer
@@ -208,13 +182,8 @@ public class OutboxToServiceBusIntegrationTests
     public async Task CreateCustomer_ShouldArchivePayloadsToAspireBlobStorage()
     {
         // Arrange
-        var appHost = await DistributedApplicationTestingBuilder
-            .CreateAsync<Projects.StarterApp_AppHost>();
-        await using var app = await appHost.BuildAsync();
-        await app.StartAsync();
-
-        var httpClient = app.CreateHttpClient("api");
-        ConfigureGatewayIdentity(httpClient);
+        var app = _fixture.App;
+        var httpClient = _fixture.CreateApiClient();
         await PollForHealthyAsync(httpClient, "/health/ready");
 
         var correlationId = $"aspire-{Guid.NewGuid():N}";
@@ -344,14 +313,6 @@ public class OutboxToServiceBusIntegrationTests
         }
     }
 
-    private static void ConfigureGatewayIdentity(HttpClient client)
-    {
-        client.DefaultRequestHeaders.Add("X-Authenticated-Subject", "apphost-test-user");
-        client.DefaultRequestHeaders.Add("X-Authenticated-Principal-Type", "User");
-        client.DefaultRequestHeaders.Add("X-Authenticated-Tenant-Id", "apphost-test-tenant");
-        client.DefaultRequestHeaders.Add("X-Authenticated-Scopes", "customers:read customers:write orders:read orders:write products:read products:write");
-        client.DefaultRequestHeaders.Add("X-Authenticated-Amr", "mfa pwd");
-    }
 
     private static async Task<(string BlobName, string Content)> PollForBlobContentAsync(
         string storageConnectionString,

--- a/src/StarterApp.AppHost.Tests/OutboxToServiceBusIntegrationTests.cs
+++ b/src/StarterApp.AppHost.Tests/OutboxToServiceBusIntegrationTests.cs
@@ -81,9 +81,10 @@ public class OutboxToServiceBusIntegrationTests
     [Fact]
     public async Task HealthEndpoints_ShouldBeReachable()
     {
-        // Arrange
+        // Arrange — anonymous on purpose: orchestrator probes carry no gateway identity, so a
+        // regression that puts auth in front of readiness/liveness must fail HERE.
         var app = _fixture.App;
-        var httpClient = _fixture.CreateApiClient();
+        var httpClient = _fixture.CreateAnonymousApiClient();
 
         // Wait for full readiness before checking all endpoints
         await PollForHealthyAsync(httpClient, "/health/ready");


### PR DESCRIPTION
Single distributed-app boot for the E2E collection (5 boots → 1). Test-only refactor; the CI aspire job on this PR is the verification (local Docker unavailable).

Final item of the complexity-review port backlog — see docs/ROADMAP.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * E2E test infrastructure now boots the distributed application once per test collection (reducing boots from 5 to 1).
  * Tests refactored to use a shared fixture and shared API client helpers, simplifying setup and removing redundant local app boots.

* **Documentation**
  * Roadmap updated to mark the shared E2E fixture work as DONE and note CI verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->